### PR TITLE
Use env to select tclsh path.

### DIFF
--- a/.scripts/clicat.tcl
+++ b/.scripts/clicat.tcl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/tclsh
+#!/usr/bin/env tclsh
 
 # clicat.tcl - Based on "quickscript.tcl"
 # Portions Copyright (C) 2013 Paul Halliday <paul.halliday@gmail.com>

--- a/.scripts/cliscript.tcl
+++ b/.scripts/cliscript.tcl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/tclsh
+#!/usr/bin/env tclsh
 
 # cliscript.tcl - Based on "quickscript.tcl"
 # Portions Copyright (C) 2012 Paul Halliday <paul.halliday@gmail.com>


### PR DESCRIPTION
Use env to determine tclsh path rather than assume it's located
in /usr/local/bin.
