### PR TITLE
Change logic behind "check all" selection to RT events.

### DIFF
--- a/.js/squert.js
+++ b/.js/squert.js
@@ -1129,16 +1129,17 @@ $(document).ready(function(){
           // Create sid.cid list
           sids = c_sid.split(",");
           cids = c_cid.split(",");
-          $.each(sids, function(a,b) {
-            scid += b + "." + cids[a] + ",";
-          });
 
-          // How many events are not categorized?
+          // How many events are not categorized? Create scid based on status.
           es0 = theData[i].c_status.split(",");
           var unclass = 0;                  
           $.each(es0, function(a,b) {
             switch (b) {
-              case "0": unclass++; break;
+              case "0": unclass++; 
+                        $.each(sids, function(a,b) {
+                           scid += b + "." + cids[a] + ",";
+                        });
+                        break;
             }
           });
                  
@@ -1189,6 +1190,7 @@ $(document).ready(function(){
         // If queue is empty provide event sums in case the user 
         // intends to reclass anything
         if (rtCount == 0) {
+          $("#ca0").hide();
           curclasscount = tlCount;
         } else {
           curclasscount = rtCount;


### PR DESCRIPTION
This changes the logic behind how events are selected for mass
classification when the check all box is selected. Currently,
the logic selects all events within a specific row regardless
of whether they have already been classified or not with the
side effect of reclassifying already previously classified events.

e.g. If a row having 100 RT events and 200 classified events will
include a check all box to mass classify the 100 RT events. The
current logic will classify all 300 events.

This patch also resolves the "Too many events in current selection"
UI error by not counting previously classified events.
