### PR TITLE
Fix for wrong signatures display

### DIFF
--- a/.inc/callback.php
+++ b/.inc/callback.php
@@ -121,7 +121,12 @@ function si() {
 
                     foreach($ruleLines as $line) {
 
-                        $searchCount = preg_match("/sid\:\s*$sigID\s*\;/",$line);
+                        if ( $gID > 100 ) {
+                                $searchCount = preg_match("/sid\:\s*$sigID\s*\;\s*gid\:\s*$gID\s*\;/",$line);
+                        } else {
+                                $searchCount = preg_match("/sid\:\s*$sigID\s*\;/",$line);
+                        }
+
 
                         if($searchCount > 0) {
                             $tempMsg = preg_match("/\bmsg\s*:\s*\"(.+?)\"\s*;/i",$line,$ruleMsg);


### PR DESCRIPTION
For signatures like "sensitive_data: sensitive data - eMail addresses" (sid:5 gid:138) squert was displaying the wrong description.
