### PR TITLE
CIDR support for autocat validation regexp

### DIFF
--- a/.js/squertBoxes.js
+++ b/.js/squertBoxes.js
@@ -938,10 +938,10 @@ $(document).ready(function(){
       var sl = [1,2,11,12,13,14,15,16,17];
       if (sl.indexOf(Number(ruleTxt.status)) == -1) throw 2;
 
-      // Validate IPs
-      var OK = chkIP(ruleTxt.src_ip);
+      // Validate IPs or CIDRs
+      var OK = chkCIDR(ruleTxt.src_ip);
       if (!OK) throw 3;     
-      var OK = chkIP(ruleTxt.dst_ip);
+      var OK = chkCIDR(ruleTxt.dst_ip);
       if (!OK) throw 3;
 
       // Validate ports

--- a/.js/squertFunctions.js
+++ b/.js/squertFunctions.js
@@ -134,6 +134,12 @@ function h2s(hex) {
   return str;
 }
 
+function chkCIDR(net) {
+  var re = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(\/\d{1,2})?$|^any$/;
+  var OK = re.exec(net);
+  return OK;
+}
+
 function chkIP(ip) {
   var re = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$|^any$/;
   var OK = re.exec(ip);


### PR DESCRIPTION
To my knowledge, autocategorization accepts CIDR syntax.

I've changed the validation regexp from IP-only to CIDR.
