### PR TITLE
Avoid hard loop when file unavailable

### DIFF
--- a/.scripts/ip2c.tcl
+++ b/.scripts/ip2c.tcl
@@ -403,8 +403,7 @@ if {$fail == "no"} {
                         set x [expr $x - 1]
                     }
                 } else {
-                    puts "Checksum not found. Retrying..\n"
-                    set x [expr $x - 1]
+                    puts "Checksum not found. Skipping..\n"
                 }
             }       
 


### PR DESCRIPTION
When the download is not available, this script gets stuck in a hard loop retrying, filling up both logfiles and bandwidth to a proxy.  This patch neuters the retry attempt by just continuing on.